### PR TITLE
Fix task 4 discontinuous predicates and singleton variables warnings

### DIFF
--- a/Prolog/Task4/Restaurante.pl
+++ b/Prolog/Task4/Restaurante.pl
@@ -2,6 +2,14 @@
 % Sistema de consultas para saloneros de restaurante
 % =======================================
 
+% Para suprimir warnings de definición discontinua de predicados.
+:- discontiguous plato/2.
+:- discontiguous alergico/2.
+:- discontiguous cliente/1.
+:- discontiguous caracteristica/2.
+:- discontiguous carne/1.
+:- discontiguous origen_animal/1.
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% INGREDIENTES
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -180,12 +188,12 @@ puede_comer(Cliente, Plato) :-
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 % Caso 1: Si el cliente es vegano
-cumple_restricciones(Cliente, Plato, Ingredientes) :-
+cumple_restricciones(Cliente, Plato, _) :-
     caracteristica(Cliente, vegano),
     vegano(Plato).
 
 % Caso 2: Si el cliente es vegetariano
-cumple_restricciones(Cliente, Plato, Ingredientes) :-
+cumple_restricciones(Cliente, Plato, _) :-
     caracteristica(Cliente, vegetariano),
     vegetariano(Plato).
 


### PR DESCRIPTION
# Summary
Fixes warnings for discontinuous predicates and single variables warnings.

## Discontinuous predicates example
```prolog
plato(socrates, teacher).
other_pred(x).            % <-- another predicate in between
plato(aristotle, student).
```

Fix

```prolog
% Include at the top of the file
:- discontiguous plato/2.
```

## Singleton variables example
```prolog
cumple_restricciones(Cliente, Plato, Ingredientes) :-
    caracteristica(Cliente, vegano),
    vegano(Plato).
```

Fix
```prolog
cumple_restricciones(Cliente, Plato, _) :-
    caracteristica(Cliente, vegano),
    vegano(Plato).
```
